### PR TITLE
10473-preference-center-wordpress-shortcode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,4 +18,4 @@ jobs:
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-        VERSION: 3.0.0
+        VERSION: 3.1.0

--- a/readme.txt
+++ b/readme.txt
@@ -42,3 +42,6 @@ If you are having problems activating your plugin, please contact Second Street'
 
 = 3.0.0 =
 * Support for the ss-feed shortcode
+
+= 3.1.0 =
+* Support for the ss-preferences shortcode

--- a/secondstreet-promotion.php
+++ b/secondstreet-promotion.php
@@ -48,7 +48,6 @@ function ss_promo_func( $atts, $content = null ) {
 	return '<script src="' . esc_url( $ss_script_url ) . '" data-ss-embed="promotion" data-opguid="' . esc_attr( $a['op_guid'] ) . '" data-routing="' . esc_attr( $a['routing'] ) . '"></script>';
 
 }
-add_shortcode( 'ss-promo', 'ss_promo_func' );
 
 // [ss-signup] Code
 function ss_signup_func( $atts, $content = null ) {
@@ -61,10 +60,6 @@ function ss_signup_func( $atts, $content = null ) {
 	return '<script src="' . esc_url( $ss_script_url ) . '" data-ss-embed="optin" data-design-id="' . esc_attr( $a['design_id'] ) . '"></script>';
 
 }
-
-add_shortcode( 'ss-promo', 'ss_promo_func' );
-add_shortcode( 'ss-signup', 'ss_signup_func' );
-
 
 // [ss-contest] Code
 function ss_contest_func( $atts, $content = null ) {
@@ -100,8 +95,23 @@ function ss_feed_func( $atts, $content = null ) {
 	return '<script src="' . esc_url( $ss_script_url ) . '" data-ss-embed="feed" data-organization-id="' . $a['organization_id'] . '"></script>';
 }
 
+// [ss-preferences] Code
+function ss_preferences_func( $atts, $content = null ) {
+	if (empty($atts['organization_id'])) {
+		return 'Error: No organization_id parameter defined on the shortcode.';
+	}
+
+	$a = shortcode_atts( array (
+		'organization_id' => '',
+	), $atts );
+
+	$ss_script_url = 'https://embed.secondstreetapp.com/Scripts/dist/preferences.js';
+
+	return '<script src="' . esc_url( $ss_script_url ) . '" data-ss-embed="preferences" data-organization-id="' . esc_attr( $a['organization_id'] ) . '"></script>';
+}
+
 add_shortcode( 'ss-promo', 'ss_promo_func' );
 add_shortcode( 'ss-signup', 'ss_signup_func' );
-
 add_shortcode( 'ss-contest', 'ss_contest_func' );
 add_shortcode( 'ss-feed', 'ss_feed_func' );
+add_shortcode( 'ss-preferences', 'ss_preferences_func' );


### PR DESCRIPTION
[:card_index: Trello](https://trello.com/c/oLgIp0fi/10473-preference-center-wordpress-shortcode)

- Adds Wordpress Shortcode support for embeddable preference center.