### PR TITLE
10768-update-ss-embed-readme-and-fix-embeddable-promo-feeds-on-dev

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,4 +17,4 @@ jobs:
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-        VERSION: 3.1.2
+        VERSION: 3.1.3

--- a/readme.txt
+++ b/readme.txt
@@ -43,5 +43,5 @@ If you are having problems activating your plugin, please contact Second Street'
 = 3.0.0 =
 * Support for the ss-feed shortcode
 
-= 3.1.2 =
+= 3.1.3 =
 * Support for the ss-preferences shortcode

--- a/secondstreet-promotion.php
+++ b/secondstreet-promotion.php
@@ -40,13 +40,18 @@ function ss_promo_func( $atts, $content = null ) {
 	$a = shortcode_atts( array (
 			'op_id' => '',
 			'op_guid' => '',
-			'routing' => ''
+			'routing' => '',
+			'dev' => ''
 		), $atts );
 
-	$ss_script_url = 'https://embed-' . $a['op_id'] . '.secondstreetapp.com/Scripts/dist/embed.js';
+	$ss_script_url_prefix = 'https://embed' . $a['op_id'];
+	$ss_script_url_suffix = '.secondstreetapp.com/Scripts/dist/embed.js';
 
-	return '<script src="' . esc_url( $ss_script_url ) . '" data-ss-embed="promotion" data-opguid="' . esc_attr( $a['op_guid'] ) . '" data-routing="' . esc_attr( $a['routing'] ) . '"></script>';
-
+	if ( $a['dev'] === 'true' ) {
+		return '<script src="' . esc_url( $ss_script_url_prefix . '.dev' . $ss_script_url_suffix ) . '" data-ss-embed="feed" data-organization-id="' . $a['organization_id'] . '"></script>';
+	} else {
+		return '<script src="' . esc_url( $ss_script_url_prefix . '-' . $a['op_id'] . $ss_script_url_suffix ) . '" data-ss-embed="promotion" data-opguid="' . esc_attr( $a['op_guid'] ) . '" data-routing="' . esc_attr( $a['routing'] ) . '"></script>';
+	}
 }
 
 // [ss-signup] Code
@@ -88,7 +93,7 @@ function ss_feed_func( $atts, $content = null ) {
 	
 	$a = shortcode_atts( array (
 		'organization_id' => '',
-		'dev' => '',
+		'dev' => ''
 	), $atts );
 
 	$ss_script_url_prefix = 'https://o-' . $a['organization_id'];

--- a/secondstreet-promotion.php
+++ b/secondstreet-promotion.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Second Street
  * Description: Plugin will allow Second Street Affiliates to embed a Second Street Promotion within their WordPress site(s).
- * Version: 3.1.2
+ * Version: 3.1.3
  * Author: Second Street
  * Author URI: http://secondstreet.com
  * License: GPL2

--- a/secondstreet-promotion.php
+++ b/secondstreet-promotion.php
@@ -88,11 +88,17 @@ function ss_feed_func( $atts, $content = null ) {
 	
 	$a = shortcode_atts( array (
 		'organization_id' => '',
+		'dev' => '',
 	), $atts );
 
-	$ss_script_url = 'https://o-' . $a['organization_id'] . '.secondstreetapp.com/Scripts/dist/feed.js';
+	$ss_script_url_prefix = 'https://o-' . $a['organization_id'];
+	$ss_script_url_suffix = '.secondstreetapp.com/Scripts/dist/feed.js';
 
-	return '<script src="' . esc_url( $ss_script_url ) . '" data-ss-embed="feed" data-organization-id="' . $a['organization_id'] . '"></script>';
+	if ( $a['dev'] === 'true' ) {
+		return '<script src="' . esc_url( $ss_script_url_prefix . '.dev' . $ss_script_url_suffix ) . '" data-ss-embed="feed" data-organization-id="' . $a['organization_id'] . '"></script>';
+	} else {
+		return '<script src="' . esc_url( $ss_script_url_prefix . $ss_script_url_suffix ) . '" data-ss-embed="feed" data-organization-id="' . $a['organization_id'] . '"></script>';
+	}
 }
 
 // [ss-preferences] Code

--- a/secondstreet-promotion.php
+++ b/secondstreet-promotion.php
@@ -48,7 +48,7 @@ function ss_promo_func( $atts, $content = null ) {
 	$ss_script_url_suffix = '.secondstreetapp.com/Scripts/dist/embed.js';
 
 	if ( $a['dev'] === 'true' ) {
-		return '<script src="' . esc_url( $ss_script_url_prefix . '.dev' . $ss_script_url_suffix ) . '" data-ss-embed="feed" data-organization-id="' . $a['organization_id'] . '"></script>';
+		return '<script src="' . esc_url( $ss_script_url_prefix . 'dev' . $ss_script_url_suffix ) . '" data-ss-embed="feed" data-organization-id="' . $a['organization_id'] . '"></script>';
 	} else {
 		return '<script src="' . esc_url( $ss_script_url_prefix . '-' . $a['op_id'] . $ss_script_url_suffix ) . '" data-ss-embed="promotion" data-opguid="' . esc_attr( $a['op_guid'] ) . '" data-routing="' . esc_attr( $a['routing'] ) . '"></script>';
 	}


### PR DESCRIPTION
[:card_index: Trello](https://trello.com/c/qdqeCyHK/10768-update-ss-embed-readme-and-fix-embeddable-promo-feeds-on-dev)

- Adds support for dev URLs for promotion feeds. Organizations on dev will have an additional attribute in their Wordpress Shortcode: `[ss-feed organization_id="32953" dev="true"]`