### PR TITLE
bumping version to 3.1.9 as 3.1.8 cannot be redeployed in WordPress

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,4 +17,4 @@ jobs:
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-        VERSION: 3.1.8
+        VERSION: 3.1.9

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Second Street
 Tags: Page, Post, Shortcode, Promotion, Second Street, UPICKEM
 Requires at least: 3.0
 Tested up to: 6.1.1
-Stable tag: 3.1.8
+Stable tag: 3.1.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -50,4 +50,7 @@ If you are having problems activating your plugin, please contact Second Street'
 * Escape echoed data to help prevent XSS attacks
 
 = 3.1.8 =
+* Version update
+
+= 3.1.9 =
 * Version update

--- a/secondstreet-promotion.php
+++ b/secondstreet-promotion.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Second Street
  * Description: Plugin will allow Second Street Affiliates to embed a Second Street Promotion within their WordPress site(s).
- * Version: 3.1.8
+ * Version: 3.1.9
  * Author: Second Street
  * Author URI: http://secondstreet.com
  * License: GPL2


### PR DESCRIPTION
previously i tried redeploying the changes with already merged 3.1.8 version but it doesn't allow as the workflow checks for already used version and it terminates the workflow.
hence we have to make a new version and redeploy with new version
